### PR TITLE
Allow to control JPG quality via options

### DIFF
--- a/lib/pdf2img.js
+++ b/lib/pdf2img.js
@@ -145,7 +145,7 @@ var convertPdf2Img = function(input, output, page, callback) {
       if (err) {
         return callback({
           result: 'error',
-          message: 'Can not write output file.'
+          message: 'Can not write output file.' + JSON.stringify( err )
         }, null);
       }
 

--- a/lib/pdf2img.js
+++ b/lib/pdf2img.js
@@ -9,6 +9,7 @@ var options = {
   type: 'jpg',
   size: 1024,
   density: 600,
+  quality: 100,
   outputdir: null,
   outputname: null,
   page: null
@@ -20,6 +21,7 @@ Pdf2Img.prototype.setOptions = function(opts) {
   options.type = opts.type || options.type;
   options.size = opts.size || options.size;
   options.density = opts.density || options.density;
+  options.quality = opts.quality || options.quality;
   options.outputdir = opts.outputdir || options.outputdir;
   options.outputname = opts.outputname || options.outputname;
   options.page = opts.page || options.page;
@@ -138,7 +140,7 @@ var convertPdf2Img = function(input, output, page, callback) {
   gm(input, filename)
     .density(options.density, options.density)
     .resize(options.size)
-    .quality(100)
+    .quality(options.quality)
     .write(output, function(err) {
       if (err) {
         return callback({


### PR DESCRIPTION
In the original version the generated JPG always has a quality score of 100 leading to excellent but huge pictures.

For certain use cases, a quality of e.g. 80% is perfect and therefore this metric should be manageable via options.