### PR TITLE
Jpg compression quality option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ pdf2img.setOptions({
   density: 600,                               // default 600
   outputdir: __dirname + path.sep + 'output', // output folder, default null (if null given, then it will create folder name same as file name)
   outputname: 'test',                         // output file name, dafault null (if null given, then it will create image name same as input name)
-  page: null                                  // convert selected page, default null (if null given, then it will convert all pages)
+  page: null,                                 // convert selected page, default null (if null given, then it will convert all pages)
+  quality: 100                                // jpg compression quality, default: 100
 });
 
 pdf2img.convert(input, function(err, info) {

--- a/lib/pdf2img.js
+++ b/lib/pdf2img.js
@@ -11,7 +11,8 @@ var options = {
   density: 600,
   outputdir: null,
   outputname: null,
-  page: null
+  page: null,
+  quality: 100
 };
 
 var Pdf2Img = function() {};
@@ -23,6 +24,7 @@ Pdf2Img.prototype.setOptions = function(opts) {
   options.outputdir = opts.outputdir || options.outputdir;
   options.outputname = opts.outputname || options.outputname;
   options.page = opts.page || options.page;
+  options.quality = opts.quality || options.quality;
 };
 
 Pdf2Img.prototype.convert = function(input, callbackreturn) {
@@ -134,11 +136,10 @@ var convertPdf2Img = function(input, output, page, callback) {
   }
 
   var filename = filepath + '[' + (page - 1) + ']';
-
   gm(input, filename)
     .density(options.density, options.density)
     .resize(options.size)
-    .quality(100)
+    .quality(options.quality)
     .write(output, function(err) {
       if (err) {
         return callback({

--- a/test/index.js
+++ b/test/index.js
@@ -8,11 +8,6 @@ var pdf2img = require('../index.js');
 
 var input   = __dirname + path.sep + 'test.pdf';
 
-pdf2img.setOptions({
-  outputdir: __dirname + path.sep + '/output',
-  outputname: 'test'
-});
-
 describe('Split and convert pdf into images', function() {
   it ('Create jpg files', function(done) {
     this.timeout(100000);
@@ -83,6 +78,19 @@ describe('Split and convert pdf into images', function() {
         isFileExists(file.path).should.to.be.true;
         done();
       }
+    });
+  });
+  it ('Can pass quality to jpg files', function(done) {
+    this.timeout(100000);
+    pdf2img.setOptions({ type: 'jpg', page: 2 });
+    pdf2img.convert(input, function(err, info) {
+      var file1Info = info;
+      pdf2img.setOptions({ quality: 60 });
+      pdf2img.convert(input, function(err, info) {
+        var file2Info = info;
+        file1Info.message[0].size.should.gt(file2Info.message[0].size);
+        done();
+      });
     });
   });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -83,12 +83,10 @@ describe('Split and convert pdf into images', function() {
   it ('Can pass quality to jpg files', function(done) {
     this.timeout(100000);
     pdf2img.setOptions({ type: 'jpg', page: 2 });
-    pdf2img.convert(input, function(err, info) {
-      var file1Info = info;
+    pdf2img.convert(input, function(err, info1) {
       pdf2img.setOptions({ quality: 60 });
-      pdf2img.convert(input, function(err, info) {
-        var file2Info = info;
-        file1Info.message[0].size.should.gt(file2Info.message[0].size);
+      pdf2img.convert(input, function(err, info2) {
+        info1.message[0].size.should.gt(info2.message[0].size);
         done();
       });
     });


### PR DESCRIPTION
Hardcoded quality 100 for jpg compression resulted too big images for our use.

Added test, implementation and documentation for passing `quality` option to the module. Kept default value in 100 for backwards compatibility.