### PR TITLE
Feature: Convert multiple pdf files

### DIFF
--- a/lib/pdf2img.js
+++ b/lib/pdf2img.js
@@ -16,11 +16,11 @@ var options = {
 var Pdf2Img = function() {};
 
 Pdf2Img.prototype.setOptions = function(opts) {
-  options.type = opts.type || options.type;
-  options.size = opts.size || options.size;
-  options.density = opts.density || options.density;
-  options.outputdir = opts.outputdir || options.outputdir;
-  options.outputname = opts.outputname || options.outputname;
+  options.type = opts.type;
+  options.size = opts.size;
+  options.density = opts.density;
+  options.outputdir = opts.outputdir;
+  options.outputname = opts.outputname;
 };
 
 Pdf2Img.prototype.convert = function(input, callbackreturn) {
@@ -165,5 +165,32 @@ var isFileExists = function(path) {
     return false;
   }
 }
+
+
+// Convert list of pdf files, 1st argument is array of pdf files, 2nd argument need to pass opts object to set options variable
+Pdf2Img.prototype.convertList = function(arr, opts, callbackreturn) {
+  async.eachSeries(arr, function(file, callback) {
+    Pdf2Img.prototype.setOptions(opts);
+    Pdf2Img.prototype.convert(file, function(err, info) {
+      if(err) {
+        return callback({
+          result: 'error',
+          message: 'Unable to convert file ' + file
+        }, null);
+      } else {
+        return callback(null, info);
+      }
+    });
+  }, function(err) {
+      if(err) {
+        return callbackreturn({
+          result: 'error',
+          message: 'Unable to convert everything on array'
+        });
+      } else {
+        return callbackreturn(null, 'All files have been converted');
+      }
+    });
+};
 
 module.exports = new Pdf2Img;


### PR DESCRIPTION
- Remove "or" assignment on Pdf2Img.prototype.setOptions() to avoid overwriting options object whenever
Pdf2Img.prototype.convert is called.
- Added function Pdf2Img.prototype.convertList() to convert list of pdf
files in array. 1st argument is the array, 2nd argument is the "options"
object.