### PR TITLE
Allow multiple pdf files to be converted

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 A nodejs module for converting pdf into image file
 
+## Dependencies
+- GraphicsMagick
+
+Note: Windows users, please be sure GraphicsMagick and Ghostscript are installed (see https://stackoverflow.com/questions/18733695/cimg-error-gm-exe-is-not-recognized-as-an-internal-or-external-command/45783910#45783910 for details) - then it works fine on Windows.
+
 ## Installation
 ```
   $ [sudo] npm install pdf2img
@@ -21,7 +26,8 @@ pdf2img.setOptions({
   size: 1024,                                 // default 1024
   density: 600,                               // default 600
   outputdir: __dirname + path.sep + 'output', // output folder, default null (if null given, then it will create folder name same as file name)
-  outputname: 'test'                          // output file name, dafault null (if null given, then it will create image name same as input name)
+  outputname: 'test',                         // output file name, dafault null (if null given, then it will create image name same as input name)
+  page: null                                  // convert selected page, default null (if null given, then it will convert all pages)
 });
 
 pdf2img.convert(input, function(err, info) {
@@ -48,11 +54,6 @@ It will return array of splitted and converted image files.
        size: 24.055,
        path: '/output/test_3.jpg' } ] }
 ```
-
-Note that pdf2img will split and convert all pages.
-
-## To Do
-* Convert selected pages
 
 ## Maintainer
 [Fitra Aditya][0]

--- a/lib/pdf2img.js
+++ b/lib/pdf2img.js
@@ -10,27 +10,17 @@ var options = {
   size: 1024,
   density: 600,
   outputdir: null,
-  outputname: null,
-  page: null
+  outputname: null
 };
 
 var Pdf2Img = function() {};
 
 Pdf2Img.prototype.setOptions = function(opts) {
-<<<<<<< HEAD
   options.type = opts.type;
   options.size = opts.size;
   options.density = opts.density;
   options.outputdir = opts.outputdir;
   options.outputname = opts.outputname;
-=======
-  options.type = opts.type || options.type;
-  options.size = opts.size || options.size;
-  options.density = opts.density || options.density;
-  options.outputdir = opts.outputdir || options.outputdir;
-  options.outputname = opts.outputname || options.outputname;
-  options.page = opts.page || options.page;
->>>>>>> refs/remotes/origin/master
 };
 
 Pdf2Img.prototype.convert = function(input, callbackreturn) {
@@ -74,35 +64,20 @@ Pdf2Img.prototype.convert = function(input, callbackreturn) {
 
   async.waterfall([
     // Get pages count
-        function (callback) {
-             gm(input).identify("%p ", function (err, value) {
-                var pageCount = String(value).split(' ');
+    function(callback) {
+      var cmd = 'gm identify -format "%p " "' + input + '"';
+      var execSync = require('child_process').execSync;
+      var pageCount = execSync(cmd).toString().match(/[0-9]+/g);
 
-                if (!pageCount.length) {
-                    callback({
-                        result: 'error',
-                        message: 'Invalid page number.'
-                    }, null);
-                } else {
-                    // Convert selected page
-                    if (options.page !== null) {
-                        if (options.page < pageCount.length) {
-                            callback(null, [options.page]);
-                        } else {
-                            callback({
-                                result: 'error',
-                                message: 'Invalid page number.'
-                            }, null);
-                        }
-                    } else  {
-                        callback(null, pageCount);
-                    }
-                }
+      if (!pageCount.length) {
+        callback({
+          result: 'error',
+          message: 'Invalid page number.'
+        }, null);
+      }
 
-            })
-
-        },
-
+      callback(null, pageCount);
+    },
 
     // Convert pdf file
     function(pages, callback) {
@@ -113,16 +88,16 @@ Pdf2Img.prototype.convert = function(input, callbackreturn) {
 
         convertPdf2Img(inputStream, outputFile, parseInt(page), function(error, result) {
           if (error) {
-            return callbackmap(error);
+            callbackmap(error);
           }
 
           stdout.push(result);
-          return callbackmap(error, result);
+          callbackmap(error, result);
         });
       }, function(e) {
         if (e) callback(e);
 
-        return callback(null, {
+        callback(null, {
           result: 'success',
           message: stdout
         });
@@ -135,7 +110,7 @@ var convertPdf2Img = function(input, output, page, callback) {
   if (input.path) {
     var filepath = input.path;
   } else {
-    return callback({
+    callback({
       result: 'error',
       message: 'Invalid input file path.'
     }, null);
@@ -149,14 +124,14 @@ var convertPdf2Img = function(input, output, page, callback) {
     .quality(100)
     .write(output, function(err) {
       if (err) {
-        return callback({
+        callback({
           result: 'error',
           message: 'Can not write output file.'
         }, null);
       }
 
       if (!(fs.statSync(output)['size'] / 1000)) {
-        return callback({
+        callback({
           result: 'error',
           message: 'Zero sized output image detected.'
         }, null);
@@ -169,7 +144,7 @@ var convertPdf2Img = function(input, output, page, callback) {
         path: output
       };
 
-      return callback(null, results);
+      callback(null, results);
     });
 };
 
@@ -199,21 +174,21 @@ Pdf2Img.prototype.convertList = function(arr, opts, callbackreturn) {
     Pdf2Img.prototype.convert(file, function(err, info) {
       if(err) {
         return callback({
-          result: 'error',
-          message: 'Unable to convert file ' + file
+          error: 'Unable to convert file ' + file,
+          message: err
         }, null);
       } else {
-        return callback(null, info);
+        callback(null, info);
       }
     });
   }, function(err) {
       if(err) {
         return callbackreturn({
-          result: 'error',
-          message: 'Unable to convert everything on array'
-        });
+          error: 'Unable to convert everything on array',
+          message: err,
+        }, null);
       } else {
-        return callbackreturn(null, 'All files have been converted');
+        callbackreturn(null, 'All files have been converted');
       }
     });
 };

--- a/lib/pdf2img.js
+++ b/lib/pdf2img.js
@@ -16,11 +16,11 @@ var options = {
 var Pdf2Img = function() {};
 
 Pdf2Img.prototype.setOptions = function(opts) {
-  options.type = opts.type || options.type;
-  options.size = opts.size || options.size;
-  options.density = opts.density || options.density;
-  options.outputdir = opts.outputdir || options.outputdir;
-  options.outputname = opts.outputname || options.outputname;
+  options.type = opts.type;
+  options.size = opts.size;
+  options.density = opts.density;
+  options.outputdir = opts.outputdir;
+  options.outputname = opts.outputname;
 };
 
 Pdf2Img.prototype.convert = function(input, callbackreturn) {
@@ -165,5 +165,32 @@ var isFileExists = function(path) {
     return false;
   }
 }
+
+
+// Convert list of pdf files, 1st argument is array of pdf files, 2nd argument need to pass opts object to set options variable
+Pdf2Img.prototype.convertList = function(arr, opts, callbackreturn) {
+  async.eachSeries(arr, function(file, callback) {
+    Pdf2Img.prototype.setOptions(opts);
+    Pdf2Img.prototype.convert(file, function(err, info) {
+      if(err) {
+        return callback({
+          result: 'error',
+          message: 'Unable to convert file ' + file
+        }, null);
+      } else {
+        return callback(null, info);
+      }
+    });
+  }, function(err) {
+      if(err) {
+        return callbackreturn({
+          result: 'error',
+          message: 'Unable to convert everything on array'
+        });
+      } else {
+        return callbackreturn(null, 'All files have been converted');
+      }
+    });
+};
 
 module.exports = new Pdf2Img;

--- a/lib/pdf2img.js
+++ b/lib/pdf2img.js
@@ -10,17 +10,27 @@ var options = {
   size: 1024,
   density: 600,
   outputdir: null,
-  outputname: null
+  outputname: null,
+  page: null
 };
 
 var Pdf2Img = function() {};
 
 Pdf2Img.prototype.setOptions = function(opts) {
+<<<<<<< HEAD
   options.type = opts.type;
   options.size = opts.size;
   options.density = opts.density;
   options.outputdir = opts.outputdir;
   options.outputname = opts.outputname;
+=======
+  options.type = opts.type || options.type;
+  options.size = opts.size || options.size;
+  options.density = opts.density || options.density;
+  options.outputdir = opts.outputdir || options.outputdir;
+  options.outputname = opts.outputname || options.outputname;
+  options.page = opts.page || options.page;
+>>>>>>> refs/remotes/origin/master
 };
 
 Pdf2Img.prototype.convert = function(input, callbackreturn) {
@@ -64,20 +74,35 @@ Pdf2Img.prototype.convert = function(input, callbackreturn) {
 
   async.waterfall([
     // Get pages count
-    function(callback) {
-      var cmd = 'gm identify -format "%p " "' + input + '"';
-      var execSync = require('child_process').execSync;
-      var pageCount = execSync(cmd).toString().match(/[0-9]+/g);
+        function (callback) {
+             gm(input).identify("%p ", function (err, value) {
+                var pageCount = String(value).split(' ');
 
-      if (!pageCount.length) {
-        callback({
-          result: 'error',
-          message: 'Invalid page number.'
-        }, null);
-      }
+                if (!pageCount.length) {
+                    callback({
+                        result: 'error',
+                        message: 'Invalid page number.'
+                    }, null);
+                } else {
+                    // Convert selected page
+                    if (options.page !== null) {
+                        if (options.page < pageCount.length) {
+                            callback(null, [options.page]);
+                        } else {
+                            callback({
+                                result: 'error',
+                                message: 'Invalid page number.'
+                            }, null);
+                        }
+                    } else  {
+                        callback(null, pageCount);
+                    }
+                }
 
-      callback(null, pageCount);
-    },
+            })
+
+        },
+
 
     // Convert pdf file
     function(pages, callback) {
@@ -88,16 +113,16 @@ Pdf2Img.prototype.convert = function(input, callbackreturn) {
 
         convertPdf2Img(inputStream, outputFile, parseInt(page), function(error, result) {
           if (error) {
-            callbackmap(error);
+            return callbackmap(error);
           }
 
           stdout.push(result);
-          callbackmap(error, result);
+          return callbackmap(error, result);
         });
       }, function(e) {
         if (e) callback(e);
 
-        callback(null, {
+        return callback(null, {
           result: 'success',
           message: stdout
         });
@@ -110,7 +135,7 @@ var convertPdf2Img = function(input, output, page, callback) {
   if (input.path) {
     var filepath = input.path;
   } else {
-    callback({
+    return callback({
       result: 'error',
       message: 'Invalid input file path.'
     }, null);
@@ -124,14 +149,14 @@ var convertPdf2Img = function(input, output, page, callback) {
     .quality(100)
     .write(output, function(err) {
       if (err) {
-        callback({
+        return callback({
           result: 'error',
           message: 'Can not write output file.'
         }, null);
       }
 
       if (!(fs.statSync(output)['size'] / 1000)) {
-        callback({
+        return callback({
           result: 'error',
           message: 'Zero sized output image detected.'
         }, null);
@@ -144,7 +169,7 @@ var convertPdf2Img = function(input, output, page, callback) {
         path: output
       };
 
-      callback(null, results);
+      return callback(null, results);
     });
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdf2img",
-  "version": "0.2.0",
+  "version": "0.5.0",
   "description": "A nodejs module for converting pdf into image",
   "author": "Fitra Aditya <fitra@g.pl>",
   "license": "MIT",

--- a/test/index.js
+++ b/test/index.js
@@ -51,6 +51,40 @@ describe('Split and convert pdf into images', function() {
       }
     });
   });
+  it ('Create jpg file only for given page', function(done) {
+    this.timeout(100000);
+    pdf2img.setOptions({ type: 'jpg', page: 1 });
+    pdf2img.convert(input, function(err, info) {
+      if (info.result !== 'success') {
+        info.result.should.equal('success');
+        done();
+      } else {
+        info.message.length.should.equal(1)
+        var file = info.message[0];
+        file.page.should.equal(1);
+        file.name.should.equal('test_1.jpg');
+        isFileExists(file.path).should.to.be.true;
+        done();
+      }
+    });
+  });
+  it ('Create png file only for given page', function(done) {
+    this.timeout(100000);
+    pdf2img.setOptions({ type: 'png', page: 2 });
+    pdf2img.convert(input, function(err, info) {
+      if (info.result !== 'success') {
+        info.result.should.equal('success');
+        done();
+      } else {
+        info.message.length.should.equal(1)
+        var file = info.message[0];
+        file.page.should.equal(2);
+        file.name.should.equal('test_2.png');
+        isFileExists(file.path).should.to.be.true;
+        done();
+      }
+    });
+  });
 });
 
 var isFileExists = function(path) {


### PR DESCRIPTION
- Remove "or" assignment on Pdf2Img.prototype.setOptions() to avoid overwriting options object whenever
Pdf2Img.prototype.convert is called.
- Added function Pdf2Img.prototype.convertList() to convert list of pdf
files in array. 1st argument is the array, 2nd argument is the "options"
object.