### PR TITLE
enable conversion of last page

### DIFF
--- a/lib/pdf2img.js
+++ b/lib/pdf2img.js
@@ -78,7 +78,7 @@ Pdf2Img.prototype.convert = function(input, callbackreturn) {
                 } else {
                     // Convert selected page
                     if (options.page !== null) {
-                        if (options.page < pageCount.length) {
+                        if (options.page <= pageCount.length) {
                             callback(null, [options.page]);
                         } else {
                             callback({


### PR DESCRIPTION
We found that it's impossible to convert the last page of a pdf. It's just due to a simple comparison error. The page numbers are in the range [1, ..., pdfLength] and if you compare with lower than pdfLength, last page can't be converted. You just have to change it to lower equals.
We would appreciate it, if you merge this and publish a new release.